### PR TITLE
chore: fixing typos in conf_manager file

### DIFF
--- a/splunktalib/conf_manager/ta_conf_manager.py
+++ b/splunktalib/conf_manager/ta_conf_manager.py
@@ -49,7 +49,7 @@ class TAConfManager:
 
     def create(self, stanza):
         """
-        @stanza: dick like object
+        @stanza: dict like object
         {
         "name": xxx,
         "k1": v1,
@@ -67,7 +67,7 @@ class TAConfManager:
 
     def update(self, stanza):
         """
-        @stanza: dick like object
+        @stanza: dict like object
         {
         "name": xxx,
         "k1": v1,


### PR DESCRIPTION
Fixing typo as this is generating warning for offensive words in the App Inspect report.