### PR TITLE
fix: deprecate file_monitor in favour of solnlib's version

### DIFF
--- a/splunktalib/file_monitor.py
+++ b/splunktalib/file_monitor.py
@@ -25,6 +25,14 @@ class FileMonitor:
         """
         :files: files to be monidtored with full path
         """
+        warnings.warn(
+            "splunktalib's FileMonitor is going to be deprecated and "
+            "removed. Please switch to solnlib's "
+            "(https://github.com/splunk/addonfactory-solutions-library-python) "
+            "version of FileMonitorChecker located in file_monitor.py.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         self._callback = callback
         self._files = files


### PR DESCRIPTION
`solnlib` (https://github.com/splunk/addonfactory-solutions-library-python) has the same functionality, so deprecating this version.