### PR TITLE
fix: Fix py3 migration related str/byte issues

### DIFF
--- a/splunktalib/common/xml_dom_parser.py
+++ b/splunktalib/common/xml_dom_parser.py
@@ -23,7 +23,6 @@ def parse_conf_xml_dom(xml_content):
     """
     @xml_content: XML DOM from splunkd
     """
-    xml_content = xml_content.decode("utf-8")
     m = re.search(r'xmlns="([^"]+)"', xml_content)
     ns = m.group(1)
     m = re.search(r'xmlns:s="([^"]+)"', xml_content)

--- a/splunktalib/conf_manager/request.py
+++ b/splunktalib/conf_manager/request.py
@@ -49,7 +49,7 @@ def content_request(uri, session_key, method, payload, err_msg):
             err_msg,
             resp.status,
             resp.reason,
-            content.decode("utf-8"),
+            content,
         )
 
         if not (method == "GET" and resp.status == 404):

--- a/splunktalib/rest.py
+++ b/splunktalib/rest.py
@@ -66,7 +66,7 @@ def splunkd_request(
                         msg_temp, splunkd_uri, resp.status, code_to_msg(resp, content)
                     )
             else:
-                return resp, content
+                return resp, content.decode("utf-8")
     else:
         return resp, content
 


### PR DESCRIPTION
Changes:
* Fixed the str/bytes related issues
---
### Issue 1

**File**: test1.py
```python
import os

splunkd_uri = "https://localhost:8089"
username = "username"
password = "password"
os.environ["SPLUNK_HOME"] = "/opt/splunk"

import splunktalib
from splunktalib.credentials import CredentialManager
from splunktalib.kv_client import KVClient

print(f"splunktalib version=", splunktalib.__version__)

session_key = CredentialManager.get_session_key(username, password, splunkd_uri)

kv_client = KVClient(splunkd_uri, session_key)
print("Collections=", kv_client.list_collection())
```
**Error:**
```log
(talib22) Desktop ➜  python test1.py
splunktalib version= 2.2.5
/Users/mchavda/Desktop/test1.py:16: DeprecationWarning: This class is deprecated. Please see https://github.com/splunk/addonfactory-ta-library-python/issues/38
  kv_client = KVClient(splunkd_uri, session_key)
Traceback (most recent call last):
  File "/Users/mchavda/Desktop/test1.py", line 17, in <module>
    print("Collections=", kv_client.list_collection())
  File "/opt/miniconda3/envs/talib22/lib/python3.10/site-packages/splunktalib/kv_client.py", line 74, in list_collection
    m = re.search(r'xmlns="([^"]+)"', content)
  File "/opt/miniconda3/envs/talib22/lib/python3.10/re.py", line 200, in search
    return _compile(pattern, flags).search(string)
TypeError: cannot use a string pattern on a bytes-like object
```

