### PR TITLE
feat: migrate from httplib2 to requests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,25 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
+name = "certifi"
+version = "2021.10.8"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.9"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
@@ -30,7 +49,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.0.2"
+version = "6.2"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -51,15 +70,12 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "httplib2"
-version = "0.19.1"
-description = "A comprehensive HTTP client library."
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
-python-versions = "*"
-
-[package.dependencies]
-pyparsing = ">=2.4.2,<3"
+python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
@@ -123,7 +139,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -165,6 +181,24 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "requests"
+version = "2.26.0"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -197,6 +231,19 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "urllib3"
+version = "1.26.7"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
 name = "zipp"
 version = "3.5.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -211,7 +258,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a1ff08ba567ee551f8eeb705c9d08ac0d654070fe00e46b7ca4602223aafe7dc"
+content-hash = "7ae4db111f525fc7322e3eb19b25a11471b4f2d30e6d7bec77d381525068e915"
 
 [metadata.files]
 atomicwrites = [
@@ -222,52 +269,74 @@ attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
+certifi = [
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.9.tar.gz", hash = "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"},
+    {file = "charset_normalizer-2.0.9-py3-none-any.whl", hash = "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"},
+]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1549e1d08ce38259de2bc3e9a0d5f3642ff4a8f500ffc1b2df73fd621a6cdfc0"},
-    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcae10fccb27ca2a5f456bf64d84110a5a74144be3136a5e598f9d9fb48c0caa"},
-    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:53a294dc53cfb39c74758edaa6305193fb4258a30b1f6af24b360a6c8bd0ffa7"},
-    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8251b37be1f2cd9c0e5ccd9ae0380909c24d2a5ed2162a41fcdbafaf59a85ebd"},
-    {file = "coverage-6.0.2-cp310-cp310-win32.whl", hash = "sha256:db42baa892cba723326284490283a68d4de516bfb5aaba369b4e3b2787a778b7"},
-    {file = "coverage-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:bbffde2a68398682623d9dd8c0ca3f46fda074709b26fcf08ae7a4c431a6ab2d"},
-    {file = "coverage-6.0.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:60e51a3dd55540bec686d7fff61b05048ca31e804c1f32cbb44533e6372d9cc3"},
-    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a6a9409223a27d5ef3cca57dd7cd4dfcb64aadf2fad5c3b787830ac9223e01a"},
-    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4b34ae4f51bbfa5f96b758b55a163d502be3dcb24f505d0227858c2b3f94f5b9"},
-    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3bbda1b550e70fa6ac40533d3f23acd4f4e9cb4e6e77251ce77fdf41b3309fb2"},
-    {file = "coverage-6.0.2-cp36-cp36m-win32.whl", hash = "sha256:4e28d2a195c533b58fc94a12826f4431726d8eb029ac21d874345f943530c122"},
-    {file = "coverage-6.0.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a82d79586a0a4f5fd1cf153e647464ced402938fbccb3ffc358c7babd4da1dd9"},
-    {file = "coverage-6.0.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3be1206dc09fb6298de3fce70593e27436862331a85daee36270b6d0e1c251c4"},
-    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9cd3828bbe1a40070c11fe16a51df733fd2f0cb0d745fb83b7b5c1f05967df7"},
-    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d036dc1ed8e1388e995833c62325df3f996675779541f682677efc6af71e96cc"},
-    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:04560539c19ec26995ecfb3d9307ff154fbb9a172cb57e3b3cfc4ced673103d1"},
-    {file = "coverage-6.0.2-cp37-cp37m-win32.whl", hash = "sha256:e4fb7ced4d9dec77d6cf533acfbf8e1415fe799430366affb18d69ee8a3c6330"},
-    {file = "coverage-6.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:77b1da5767ed2f44611bc9bc019bc93c03fa495728ec389759b6e9e5039ac6b1"},
-    {file = "coverage-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:61b598cbdbaae22d9e34e3f675997194342f866bb1d781da5d0be54783dce1ff"},
-    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36e9040a43d2017f2787b28d365a4bb33fcd792c7ff46a047a04094dc0e2a30d"},
-    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9f1627e162e3864a596486774876415a7410021f4b67fd2d9efdf93ade681afc"},
-    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e7a0b42db2a47ecb488cde14e0f6c7679a2c5a9f44814393b162ff6397fcdfbb"},
-    {file = "coverage-6.0.2-cp38-cp38-win32.whl", hash = "sha256:a1b73c7c4d2a42b9d37dd43199c5711d91424ff3c6c22681bc132db4a4afec6f"},
-    {file = "coverage-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:1db67c497688fd4ba85b373b37cc52c50d437fd7267520ecd77bddbd89ea22c9"},
-    {file = "coverage-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f2f184bf38e74f152eed7f87e345b51f3ab0b703842f447c22efe35e59942c24"},
-    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd1cf1deb3d5544bd942356364a2fdc8959bad2b6cf6eb17f47d301ea34ae822"},
-    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad9b8c1206ae41d46ec7380b78ba735ebb77758a650643e841dd3894966c31d0"},
-    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:381d773d896cc7f8ba4ff3b92dee4ed740fb88dfe33b6e42efc5e8ab6dfa1cfe"},
-    {file = "coverage-6.0.2-cp39-cp39-win32.whl", hash = "sha256:424c44f65e8be58b54e2b0bd1515e434b940679624b1b72726147cfc6a9fc7ce"},
-    {file = "coverage-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:abbff240f77347d17306d3201e14431519bf64495648ca5a49571f988f88dee9"},
-    {file = "coverage-6.0.2-pp36-none-any.whl", hash = "sha256:7092eab374346121805fb637572483270324407bf150c30a3b161fc0c4ca5164"},
-    {file = "coverage-6.0.2-pp37-none-any.whl", hash = "sha256:30922626ce6f7a5a30bdba984ad21021529d3d05a68b4f71ea3b16bda35b8895"},
-    {file = "coverage-6.0.2.tar.gz", hash = "sha256:6807947a09510dc31fa86f43595bf3a14017cd60bf633cc746d52141bfa6b149"},
+    {file = "coverage-6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92b8c845527eae547a2a6617d336adc56394050c3ed8a6918683646328fbb6da"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c7912d1526299cb04c88288e148c6c87c0df600eca76efd99d84396cfe00ef1d"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d5d2033d5db1d58ae2d62f095e1aefb6988af65b4b12cb8987af409587cc0739"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3feac4084291642165c3a0d9eaebedf19ffa505016c4d3db15bfe235718d4971"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:276651978c94a8c5672ea60a2656e95a3cce2a3f31e9fb2d5ebd4c215d095840"},
+    {file = "coverage-6.2-cp310-cp310-win32.whl", hash = "sha256:f506af4f27def639ba45789fa6fde45f9a217da0be05f8910458e4557eed020c"},
+    {file = "coverage-6.2-cp310-cp310-win_amd64.whl", hash = "sha256:3f7c17209eef285c86f819ff04a6d4cbee9b33ef05cbcaae4c0b4e8e06b3ec8f"},
+    {file = "coverage-6.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:13362889b2d46e8d9f97c421539c97c963e34031ab0cb89e8ca83a10cc71ac76"},
+    {file = "coverage-6.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:22e60a3ca5acba37d1d4a2ee66e051f5b0e1b9ac950b5b0cf4aa5366eda41d47"},
+    {file = "coverage-6.2-cp311-cp311-win_amd64.whl", hash = "sha256:b637c57fdb8be84e91fac60d9325a66a5981f8086c954ea2772efe28425eaf64"},
+    {file = "coverage-6.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f467bbb837691ab5a8ca359199d3429a11a01e6dfb3d9dcc676dc035ca93c0a9"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2641f803ee9f95b1f387f3e8f3bf28d83d9b69a39e9911e5bfee832bea75240d"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1219d760ccfafc03c0822ae2e06e3b1248a8e6d1a70928966bafc6838d3c9e48"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9a2b5b52be0a8626fcbffd7e689781bf8c2ac01613e77feda93d96184949a98e"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8e2c35a4c1f269704e90888e56f794e2d9c0262fb0c1b1c8c4ee44d9b9e77b5d"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:5d6b09c972ce9200264c35a1d53d43ca55ef61836d9ec60f0d44273a31aa9f17"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e3db840a4dee542e37e09f30859f1612da90e1c5239a6a2498c473183a50e781"},
+    {file = "coverage-6.2-cp36-cp36m-win32.whl", hash = "sha256:4e547122ca2d244f7c090fe3f4b5a5861255ff66b7ab6d98f44a0222aaf8671a"},
+    {file = "coverage-6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0"},
+    {file = "coverage-6.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb8b8ee99b3fffe4fd86f4c81b35a6bf7e4462cba019997af2fe679365db0c49"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:619346d57c7126ae49ac95b11b0dc8e36c1dd49d148477461bb66c8cf13bb521"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0a7726f74ff63f41e95ed3a89fef002916c828bb5fcae83b505b49d81a066884"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cfd9386c1d6f13b37e05a91a8583e802f8059bebfccde61a418c5808dea6bbfa"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:17e6c11038d4ed6e8af1407d9e89a2904d573be29d51515f14262d7f10ef0a64"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c254b03032d5a06de049ce8bca8338a5185f07fb76600afff3c161e053d88617"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dca38a21e4423f3edb821292e97cec7ad38086f84313462098568baedf4331f8"},
+    {file = "coverage-6.2-cp37-cp37m-win32.whl", hash = "sha256:600617008aa82032ddeace2535626d1bc212dfff32b43989539deda63b3f36e4"},
+    {file = "coverage-6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:bf154ba7ee2fd613eb541c2bc03d3d9ac667080a737449d1a3fb342740eb1a74"},
+    {file = "coverage-6.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9afb5b746781fc2abce26193d1c817b7eb0e11459510fba65d2bd77fe161d9e"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edcada2e24ed68f019175c2b2af2a8b481d3d084798b8c20d15d34f5c733fa58"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a9c8c4283e17690ff1a7427123ffb428ad6a52ed720d550e299e8291e33184dc"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f614fc9956d76d8a88a88bb41ddc12709caa755666f580af3a688899721efecd"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9365ed5cce5d0cf2c10afc6add145c5037d3148585b8ae0e77cc1efdd6aa2953"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8bdfe9ff3a4ea37d17f172ac0dff1e1c383aec17a636b9b35906babc9f0f5475"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:63c424e6f5b4ab1cf1e23a43b12f542b0ec2e54f99ec9f11b75382152981df57"},
+    {file = "coverage-6.2-cp38-cp38-win32.whl", hash = "sha256:49dbff64961bc9bdd2289a2bda6a3a5a331964ba5497f694e2cbd540d656dc1c"},
+    {file = "coverage-6.2-cp38-cp38-win_amd64.whl", hash = "sha256:9a29311bd6429be317c1f3fe4bc06c4c5ee45e2fa61b2a19d4d1d6111cb94af2"},
+    {file = "coverage-6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:215f8afcc02a24c2d9a10d3790b21054b58d71f4b3c6f055d4bb1b15cecce685"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a4bdeb0a52d1d04123b41d90a4390b096f3ef38eee35e11f0b22c2d031222c6c"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c332d8f8d448ded473b97fefe4a0983265af21917d8b0cdcb8bb06b2afe632c3"},
+    {file = "coverage-6.2-cp39-cp39-win32.whl", hash = "sha256:6e1394d24d5938e561fbeaa0cd3d356207579c28bd1792f25a068743f2d5b282"},
+    {file = "coverage-6.2-cp39-cp39-win_amd64.whl", hash = "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644"},
+    {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
+    {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
 ]
 defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
-httplib2 = [
-    {file = "httplib2-0.19.1-py3-none-any.whl", hash = "sha256:2ad195faf9faf079723f6714926e9a9061f694d07724b846658ce08d40f522b4"},
-    {file = "httplib2-0.19.1.tar.gz", hash = "sha256:0b12617eeca7433d4c396a100eaecfa4b08ee99aa881e6df6e257a7aad5d533d"},
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.6.1-py3-none-any.whl", hash = "sha256:9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e"},
@@ -301,6 +370,10 @@ pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
+requests = [
+    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
+    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+]
 sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
@@ -317,6 +390,10 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
     {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
     {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
+    {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
 ]
 zipp = [
     {file = "zipp-3.5.0-py3-none-any.whl", hash = "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ repository = "https://github.com/splunk/addonfactory-ta-library-python"
 [tool.poetry.dependencies]
 python = "^3.7"
 sortedcontainers = "^2"
-httplib2 = "^0"
 defusedxml = "^0"
+requests = "^2.26.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6"

--- a/splunktalib/common/xml_dom_parser.py
+++ b/splunktalib/common/xml_dom_parser.py
@@ -23,7 +23,6 @@ def parse_conf_xml_dom(xml_content):
     """
     @xml_content: XML DOM from splunkd
     """
-    xml_content = xml_content.decode("utf-8")
     m = re.search(r'xmlns="([^"]+)"', xml_content)
     ns = m.group(1)
     m = re.search(r'xmlns:s="([^"]+)"', xml_content)

--- a/splunktalib/credentials.py
+++ b/splunktalib/credentials.py
@@ -104,14 +104,12 @@ class CredentialManager:
             "password": password,
         }
 
-        response, content = rest.splunkd_request(
-            eid, None, method="POST", data=postargs
-        )
+        response = rest.splunkd_request(eid, None, method="POST", data=postargs)
 
-        if response is None and content is None:
+        if response is None:
             raise CredException("Get session key failed.")
 
-        xml_obj = xdm.parseString(content)
+        xml_obj = xdm.parseString(response.text)
         session_nodes = xml_obj.getElementsByTagName("sessionKey")
         if not session_nodes:
             raise CredException("Invalid username or password.")
@@ -165,13 +163,13 @@ class CredentialManager:
         except CredException:
             payload = {"password": password}
             endpoint = self._get_endpoint(name)
-            response, _ = rest.splunkd_request(
+            response = rest.splunkd_request(
                 endpoint, self._session_key, method="POST", data=payload
             )
-            if not response or response.status not in (200, 201):
+            if not response or response.status_code not in (200, 201):
                 raise CredException(
                     "Unable to update password for username={}, status={}".format(
-                        name, response.status
+                        name, response.status_code
                     )
                 )
 
@@ -188,10 +186,10 @@ class CredentialManager:
         }
 
         endpoint = self._get_endpoint(name)
-        resp, content = rest.splunkd_request(
+        resp = rest.splunkd_request(
             endpoint, self._session_key, method="POST", data=payload
         )
-        if not resp or resp.status not in (200, 201, "200", "201"):
+        if not resp or resp.status_code not in (200, 201, "200", "201"):
             raise CredException("Failed to encrypt username {}".format(name))
 
     def delete(self, name, throw=False):
@@ -236,14 +234,12 @@ class CredentialManager:
         """
 
         endpoint = self._get_endpoint(name)
-        response, content = rest.splunkd_request(
-            endpoint, self._session_key, method="DELETE"
-        )
+        response = rest.splunkd_request(endpoint, self._session_key, method="DELETE")
 
-        if response is not None and response.status in (404, "404"):
+        if response is not None and response.status_code in (404, "404"):
             if throw:
                 raise CredNotFound("Credential stanza not exits - {}".format(name))
-        elif not response or response.status not in (200, 201, "200", "201"):
+        elif not response or response.status_code not in (200, 201, "200", "201"):
             if throw:
                 raise CredException(
                     "Failed to delete credential stanza {}".format(name)
@@ -312,11 +308,13 @@ class CredentialManager:
         """
 
         endpoint = self._get_endpoint()
-        response, content = rest.splunkd_request(
-            endpoint, self._session_key, method="GET"
-        )
-        if response and response.status in (200, 201, "200", "201") and content:
-            return xdp.parse_conf_xml_dom(content)
+        response = rest.splunkd_request(endpoint, self._session_key, method="GET")
+        if (
+            response
+            and response.status_code in (200, 201, "200", "201")
+            and response.text
+        ):
+            return xdp.parse_conf_xml_dom(response.text)
         raise CredException("Failed to get credentials")
 
     def get_clear_password(self, name=None):

--- a/splunktalib/credentials.py
+++ b/splunktalib/credentials.py
@@ -189,7 +189,7 @@ class CredentialManager:
         resp = rest.splunkd_request(
             endpoint, self._session_key, method="POST", data=payload
         )
-        if not resp or resp.status_code not in (200, 201, "200", "201"):
+        if not resp or resp.status_code not in (200, 201):
             raise CredException("Failed to encrypt username {}".format(name))
 
     def delete(self, name, throw=False):
@@ -236,10 +236,10 @@ class CredentialManager:
         endpoint = self._get_endpoint(name)
         response = rest.splunkd_request(endpoint, self._session_key, method="DELETE")
 
-        if response is not None and response.status_code in (404, "404"):
+        if response is not None and response.status_code == 404:
             if throw:
                 raise CredNotFound("Credential stanza not exits - {}".format(name))
-        elif not response or response.status_code not in (200, 201, "200", "201"):
+        elif not response or response.status_code not in (200, 201):
             if throw:
                 raise CredException(
                     "Failed to delete credential stanza {}".format(name)
@@ -309,11 +309,7 @@ class CredentialManager:
 
         endpoint = self._get_endpoint()
         response = rest.splunkd_request(endpoint, self._session_key, method="GET")
-        if (
-            response
-            and response.status_code in (200, 201, "200", "201")
-            and response.text
-        ):
+        if response and response.status_code in (200, 201) and response.text:
             return xdp.parse_conf_xml_dom(response.text)
         raise CredException("Failed to get credentials")
 

--- a/splunktalib/kv_client.py
+++ b/splunktalib/kv_client.py
@@ -159,17 +159,15 @@ class KVClient:
     ):
         headers = {"Content-Type": content_type}
 
-        resp, content = rest.splunkd_request(
-            uri, self._session_key, method, headers, data
-        )
-        if resp is None and content is None:
+        resp = rest.splunkd_request(uri, self._session_key, method, headers, data)
+        if resp is None:
             raise KVException("Failed uri={}, data={}".format(uri, data))
 
-        if resp.status in (200, 201):
-            return content
-        elif resp.status == 409:
+        if resp.status_code in (200, 201):
+            return resp.text
+        elif resp.status_code == 409:
             raise KVAlreadyExists("{}-{} already exists".format(uri, data))
-        elif resp.status == 404:
+        elif resp.status_code == 404:
             raise KVNotExists("{}-{} not exists".format(uri, data))
         else:
             raise KVException(

--- a/splunktalib/modinput.py
+++ b/splunktalib/modinput.py
@@ -64,7 +64,7 @@ def _parse_modinput_configs(root, outer_block, inner_block):
     confs = root.getElementsByTagName(outer_block)
     if not confs:
         log.logger.error("Invalid config, missing %s section", outer_block)
-        raise Exception("Invalid config, missing {} section".format(outer_block))
+        raise Exception(f"Invalid config, missing {outer_block} section")
 
     configs = []
     stanzas = confs[0].getElementsByTagName(inner_block)

--- a/splunktalib/modinput.py
+++ b/splunktalib/modinput.py
@@ -64,7 +64,7 @@ def _parse_modinput_configs(root, outer_block, inner_block):
     confs = root.getElementsByTagName(outer_block)
     if not confs:
         log.logger.error("Invalid config, missing %s section", outer_block)
-        raise Exception("Invalid config, missing %s section".format(outer_block))
+        raise Exception("Invalid config, missing {} section".format(outer_block))
 
     configs = []
     stanzas = confs[0].getElementsByTagName(inner_block)

--- a/splunktalib/rest.py
+++ b/splunktalib/rest.py
@@ -15,23 +15,25 @@
 #
 
 import json
-import urllib.error
 import urllib.parse
-import urllib.request
 from traceback import format_exc
 
-from httplib2 import Http, ProxyInfo, socks
+import requests
 
 import splunktalib.common.log as log
 import splunktalib.common.util as scu
 
 
 def splunkd_request(
-    splunkd_uri, session_key, method="GET", headers=None, data=None, timeout=30, retry=1
-):
-    """
-    :return: httplib2.Response and content
-    """
+    splunkd_uri,
+    session_key,
+    method="GET",
+    headers=None,
+    data=None,
+    timeout=30,
+    retry=1,
+    verify=False,
+) -> requests.Response:
 
     headers = headers if headers is not None else {}
     headers["Authorization"] = "Splunk {}".format(session_key)
@@ -49,104 +51,45 @@ def splunkd_request(
         else:
             data = urllib.parse.urlencode(data)
 
-    http = Http(timeout=timeout, disable_ssl_certificate_validation=True)
     msg_temp = "Failed to send rest request=%s, errcode=%s, reason=%s"
-    resp, content = None, None
+    resp = None
     for _ in range(retry):
         try:
-            resp, content = http.request(
-                splunkd_uri, method=method, headers=headers, body=data
+            resp = requests.request(
+                method=method,
+                url=splunkd_uri,
+                data=data,
+                headers=headers,
+                timeout=timeout,
+                verify=verify,
             )
         except Exception:
             log.logger.error(msg_temp, splunkd_uri, "unknown", format_exc())
         else:
-            if resp.status not in (200, 201):
-                if not (method == "GET" and resp.status == 404):
+            if resp.status_code not in (200, 201):
+                if not (method == "GET" and resp.status_code == 404):
                     log.logger.debug(
-                        msg_temp, splunkd_uri, resp.status, code_to_msg(resp, content)
+                        msg_temp, splunkd_uri, resp.status_code, code_to_msg(resp)
                     )
             else:
-                return resp, content
+                return resp
     else:
-        return resp, content
+        return resp
 
 
-def code_to_msg(resp, content):
+def code_to_msg(response: requests.Response):
     code_msg_tbl = {
-        400: "Request error. reason={}".format(content),
+        400: "Request error. reason={}".format(response.text),
         401: "Authentication failure, invalid access credentials.",
         402: "In-use license disables this feature.",
         403: "Insufficient permission.",
         404: "Requested endpoint does not exist.",
-        409: "Invalid operation for this endpoint. reason={}".format(content),
-        500: "Unspecified internal server error. reason={}".format(content),
+        409: "Invalid operation for this endpoint. reason={}".format(response.text),
+        500: "Unspecified internal server error. reason={}".format(response.text),
         503: (
             "Feature is disabled in the configuration file. "
-            "reason={}".format(content)
+            "reason={}".format(response.text)
         ),
     }
 
-    return code_msg_tbl.get(resp.status, content)
-
-
-def build_http_connection(config, timeout=120, disable_ssl_validation=False):
-    """
-    :config: dict like, proxy and account information are in the following
-             format {
-                 "username": xx,
-                 "password": yy,
-                 "proxy_url": zz,
-                 "proxy_port": aa,
-                 "proxy_username": bb,
-                 "proxy_password": cc,
-                 "proxy_type": http,http_no_tunnel,sock4,sock5,
-                 "proxy_rdns": 0 or 1,
-             }
-    :return: Http2.Http object
-    """
-
-    proxy_type_to_code = {
-        "http": socks.PROXY_TYPE_HTTP,
-        "http_no_tunnel": socks.PROXY_TYPE_HTTP_NO_TUNNEL,
-        "socks4": socks.PROXY_TYPE_SOCKS4,
-        "socks5": socks.PROXY_TYPE_SOCKS5,
-    }
-    if config.get("proxy_type") in proxy_type_to_code:
-        proxy_type = proxy_type_to_code[config["proxy_type"]]
-    else:
-        proxy_type = socks.PROXY_TYPE_HTTP
-
-    rdns = scu.is_true(config.get("proxy_rdns"))
-
-    proxy_info = None
-    if config.get("proxy_url") and config.get("proxy_port"):
-        if config.get("proxy_username") and config.get("proxy_password"):
-            proxy_info = ProxyInfo(
-                proxy_type=proxy_type,
-                proxy_host=config["proxy_url"],
-                proxy_port=int(config["proxy_port"]),
-                proxy_user=config["proxy_username"],
-                proxy_pass=config["proxy_password"],
-                proxy_rdns=rdns,
-            )
-        else:
-            proxy_info = ProxyInfo(
-                proxy_type=proxy_type,
-                proxy_host=config["proxy_url"],
-                proxy_port=int(config["proxy_port"]),
-                proxy_rdns=rdns,
-            )
-    if proxy_info:
-        http = Http(
-            proxy_info=proxy_info,
-            timeout=timeout,
-            disable_ssl_certificate_validation=disable_ssl_validation,
-        )
-    else:
-        http = Http(
-            timeout=timeout, disable_ssl_certificate_validation=disable_ssl_validation
-        )
-
-    if config.get("username") and config.get("password"):
-        http.add_credentials(config["username"], config["password"])
-    return http
+    return code_msg_tbl.get(response.status_code, response.text)

--- a/splunktalib/rest.py
+++ b/splunktalib/rest.py
@@ -17,11 +17,11 @@
 import json
 import urllib.parse
 from traceback import format_exc
+from typing import Optional
 
 import requests
 
 import splunktalib.common.log as log
-import splunktalib.common.util as scu
 
 
 def splunkd_request(
@@ -33,7 +33,7 @@ def splunkd_request(
     timeout=30,
     retry=1,
     verify=False,
-) -> requests.Response:
+) -> Optional[requests.Response]:
 
     headers = headers if headers is not None else {}
     headers["Authorization"] = "Splunk {}".format(session_key)

--- a/splunktalib/splunk_cluster.py
+++ b/splunktalib/splunk_cluster.py
@@ -20,14 +20,14 @@ import splunktalib.rest as rest
 
 
 def _do_rest(uri, session_key):
-    resp, content = rest.splunkd_request(uri, session_key)
+    resp = rest.splunkd_request(uri, session_key)
     if resp is None:
         return None
 
-    if resp.status not in (200, 201):
+    if resp.status_code not in (200, 201):
         return None
 
-    stanza_objs = xdp.parse_conf_xml_dom(content)
+    stanza_objs = xdp.parse_conf_xml_dom(resp.text)
     if not stanza_objs:
         return None
 


### PR DESCRIPTION
Changes:
* feat: Migrate Httplib2 to requests library 
* BREAKING CHANGE: The 'build_http_connection' function is removed. User can directly use the 'requests.request' function
* fix: Fix minor string formatting issue

This PR also fixes the py3 migration-related str/byte issues (#47 )