### PR TITLE
ci: multiple updates to the pipeline

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -126,7 +126,6 @@ jobs:
     needs:
       - pre-commit
       - semgrep
-      - snyk
       - build
       - review_secrets
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -84,28 +84,6 @@ jobs:
         uses: returntocorp/semgrep-action@v1
         with:
           publishToken: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
-  snyk:
-    name: security-vuln-snyk
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - uses: snyk/actions/setup@master
-      - uses: actions/setup-go@v2.1.3
-        with:
-          go-version: "1.13"
-      - name: Snyk monitor
-        run: snyk test --sarif-file-output=snyk-scan_requirements.sarif --all-projects --print-deps --severity-threshold=high
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      - uses: actions/upload-artifact@v2
-        if: always() 
-        with:
-          name: snyk-results
-          path: snyk-scan_requirements.sarif
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -123,11 +101,8 @@ jobs:
         with:
           python-version: "3.7"
       - name: Install Poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
-      - name: Build
         run: |
-          # shellcheck disable=SC1090
-          source "$HOME/.poetry/env"
+          curl -sSL https://install.python-poetry.org | python3 -
           poetry build
       - uses: actions/upload-artifact@v2
         if: always() 
@@ -169,16 +144,9 @@ jobs:
         with:
           python-version: "3.7"
       - name: Install Poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
-      - name: Install Code
         run: |
-          # shellcheck disable=SC1090
-          source "$HOME/.poetry/env"
+          curl -sSL https://install.python-poetry.org | python3 -
           poetry install
-      - name: Build
-        run: |
-          # shellcheck disable=SC1090
-          source "$HOME/.poetry/env"
           poetry build
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2.6.0


### PR DESCRIPTION
From `poetry` [README](https://github.com/python-poetry/poetry#installation):

Warning: The previous get-poetry.py installer is now deprecated, if you are currently using it you should migrate to the new, supported, install-poetry.py installer.

Also removed `snyk`.