### PR TITLE
ci: update semantic version and remove node 14 workaround

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,14 @@
-# SPDX-FileCopyrightText: 2020 Splunk Inc.
-#
-# SPDX-License-Identifier: Apache-2.0
-
 version: 2
 updates:
-  # Keep package.json (& lockfiles) up to date as soon as
-  # new versions are published to the npm registry
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "daily"
-  # Keep Dockerfile up to date, batching pull requests weekly
   - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -116,9 +116,6 @@ jobs:
           # Very important: semantic-release won't trigger a tagged
           # build if this is not set false
           persist-credentials: false
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -129,9 +126,9 @@ jobs:
           poetry install
           poetry build
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2.6.0
+        uses: cycjimmy/semantic-release-action@v3.0.0
         with:
-          semantic_version: 17
+          semantic_version: 19.0.2
           extra_plugins: |
             @semantic-release/exec
             @semantic-release/git


### PR DESCRIPTION
- ci: update semantic version and remove node 14 workaround
- ci: add dependabot conf for github-actions
