### PR TITLE
Modify timeout for Escalation: ES - 11487

### DIFF
--- a/splunktalib/rest.py
+++ b/splunktalib/rest.py
@@ -30,7 +30,7 @@ def splunkd_request(
     method="GET",
     headers=None,
     data=None,
-    timeout=30,
+    timeout=300,
     retry=1,
     verify=False,
 ) -> Optional[requests.Response]:


### PR DESCRIPTION
We have seen multiple escalations for customer Premera where the 30 sec timeout value is not sufficient enough to collect data for MSCS blob collection. This update increases timeout from 30 to 300