### PR TITLE
ci: fix ubuntu version to 22.04

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -41,12 +41,12 @@ jobs:
       - name: Check License Header
         uses: apache/skywalking-eyes@v0.4.0
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.12"
       - uses: pre-commit/action@v3.0.1
   semgrep:
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Check License Header
         uses: apache/skywalking-eyes@v0.4.0
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -57,7 +57,7 @@ jobs:
     needs:
       - pre-commit
       - semgrep
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This PR sets ubuntu version to 22.04 for scripts run with python 3.7 and update python version to latest (3.12) for pre-commit.
Reference: [ADDON-75861](https://splunk.atlassian.net/browse/ADDON-75861)