### PR TITLE
fix: scheduler thread should be a daemon

### DIFF
--- a/splunktalib/schedule/scheduler.py
+++ b/splunktalib/schedule/scheduler.py
@@ -36,7 +36,7 @@ class Scheduler:
         self._wakeup_q = queue.Queue()
         self._lock = threading.Lock()
         self._thr = threading.Thread(target=self._do_jobs)
-        self._thr.deamon = True
+        self._thr.daemon = True
         self._started = False
 
     def start(self):


### PR DESCRIPTION
Because of the typo scheduler thread was not treated as a daemon thread - therefore it wouldn't exit once the main thread exitted, but would wait for itself to finish. The process needs to exit fully to reload the configuration (for example, an input is disabled or log level changed).
This was usually not a problem, as scheduler was able to exit by itself in most cases. But in some cases, when there were more tasks to schedule than task_queue_size, the scheduler would be stuck in a loop and never exit. 
This change will make it so that scheduler thread always gets killed once the main thread exits.